### PR TITLE
Feat/healthcheck

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-websocket:3.3.2'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     implementation("org.springframework.security:spring-security-messaging")
 

--- a/src/main/java/com/example/hcbc/global/health/HealthController.java
+++ b/src/main/java/com/example/hcbc/global/health/HealthController.java
@@ -1,0 +1,14 @@
+package com.example.hcbc.global.health;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/health")
+    public ResponseEntity<String> health() {
+        return ResponseEntity.ok("OK");
+    }
+}


### PR DESCRIPTION
# 개요
기존 spring-boot-starter-actuator 의존성을 사용하여 헬시체크 API를 구현하였지만
이는 적합하지 않은 방식이라고 판단하여 의존성을 삭제하고 직접 헬시체크 API를 구현하였습니다.
# 작업내용
* HealthController에서 서버에서 응답을 받으면 "OK"를 반환하도록 설계